### PR TITLE
optimize art-grid

### DIFF
--- a/assets/timber.scss.liquid
+++ b/assets/timber.scss.liquid
@@ -2409,6 +2409,8 @@ label.error {
 	    -webkit-box-shadow: 0px 3px 16px -2px rgba(0,0,0,0.2);
 		-moz-box-shadow: 0px 3px 16px -2px rgba(0,0,0,0.2);
 		box-shadow: 0px 2px 8px -2px rgba(0,0,0,0.2);
+        width: 100%;
+        max-width: auto !important;
   }
 	
 }

--- a/snippets/art-grid.liquid
+++ b/snippets/art-grid.liquid
@@ -71,7 +71,7 @@
 			{% endfor %}	
 		
 	</div>  
-    <img src="{{ product.featured_image.src | img_url: 'large' }}" alt="{{ product.featured_image.alt | escape }}">
+    <img src="{{ product.featured_image.src | img_url: 'medium' }}" alt="{{ product.featured_image.alt | escape }}">
   </a>
   
   <div class="hoverText">


### PR DESCRIPTION
use medium assets instead of large to save on load times
- needed to set artgrid img width to 100% for proper scaling
